### PR TITLE
Added test case for identity split

### DIFF
--- a/tests/torch/pruning/helpers.py
+++ b/tests/torch/pruning/helpers.py
@@ -620,6 +620,26 @@ class SplitModel(nn.Module):
         return y1, y2
 
 
+class SplitIdentityModel(nn.Module):
+    #         (input)
+    #            |
+    #         (conv1)
+    #            |
+    #         (chunk)
+    #            |
+    #         (conv2)
+    def __init__(self):
+        super().__init__()
+        self.conv1 = create_conv(1, 4, 1, 1)
+        self.conv2 = create_conv(4, 8, 1, 1)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        y1 = torch.chunk(x, chunks=1, dim=1)
+        y1 = self.conv2(y1[0])
+        return y1
+
+
 class SplitMaskPropFailModel(nn.Module):
     #         (input)
     #            |


### PR DESCRIPTION


### Changes

Added test case for identity split and added meaningful names for test cases for better debugging

### Reason for changes

Address the comment https://github.com/openvinotoolkit/nncf/pull/1244#discussion_r955930013

### Related tickets

### Tests

test_model_pruning_analysis.py
